### PR TITLE
feat: Download Sequence Variability Data as Fasta File

### DIFF
--- a/src/app/common/constants.py
+++ b/src/app/common/constants.py
@@ -1,7 +1,12 @@
-# Streamlit Session State Keys
+# Session State Keys for Gather Data page
 NCBI_SUMMARY_FORM = "NCBI_SUMMARY_FORM"
 NCBI_DF = "NCBI_DF"
 NCBI_DF_FILTER = "NCBI_DF_FILTER"
+
+# Session State Keys for Sequence Variability page
+SEQVAR_CALC_BTN = "SEQVAR_CALC_BTN"
+SEQVAR_CALCULATED = "SEQVAR_CALCULATED"
+SEQVAR_DF = "SEQVAR_DF"
 
 # Streamlit UI
 PAGE_LAYOUT = "wide"

--- a/src/app/common/data_processing.py
+++ b/src/app/common/data_processing.py
@@ -1,9 +1,11 @@
 from io import BytesIO
-from typing import Dict, List
+from typing import Dict
 
+import pandas as pd
 import streamlit as st
 
 from app.common.constants import NCBI_DF
+from genetic_testing.sequence_analysis.datatypes import GroupSequenceColumns
 
 
 def format_ncbi_summary() -> None:
@@ -103,3 +105,31 @@ def read_fasta(file: BytesIO) -> Dict[str, str]:
             sequences[current_header] = "".join(current_sequence)
 
     return sequences
+
+
+def seqvar_df_to_fasta(df: pd.DataFrame, species: str = "species") -> str:
+    """Convert a sequence variability DataFrame to FASTA format string.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        A DataFrame containing sequence variability data. It is expected to have `Sequence`, `Group_Number`, and `Count` columns.
+
+    species : str, optional
+        The name of the species, by default `species`.
+
+    Returns
+    -------
+    str
+        A string containing the sequence variability data in FASTA format.
+    """
+    cols = GroupSequenceColumns()
+    fasta_str = []
+    for _, row in df.iterrows():
+        group_number = int(row[cols.group_number])
+        count = int(row[cols.count])
+        sequence = row[cols.seq]
+
+        fasta_str.append(f">Group{group_number}_{species}_{count}\n{sequence}")
+
+    return "\n".join(fasta_str)

--- a/src/app/common/setup.py
+++ b/src/app/common/setup.py
@@ -1,7 +1,15 @@
 import pandas as pd
 import streamlit as st
 
-from app.common.constants import NCBI_DF, NCBI_DF_FILTER, NCBI_SUMMARY_FORM, PAGE_LAYOUT
+from app.common.constants import (
+    NCBI_DF,
+    NCBI_DF_FILTER,
+    NCBI_SUMMARY_FORM,
+    PAGE_LAYOUT,
+    SEQVAR_CALC_BTN,
+    SEQVAR_CALCULATED,
+    SEQVAR_DF,
+)
 
 
 def _initialize_UI() -> None:
@@ -20,6 +28,14 @@ def _initialize_session_state() -> None:
 
     if NCBI_DF not in st.session_state:
         st.session_state[NCBI_DF] = pd.DataFrame()
+
+
+def initialize_session_state_seq_var() -> None:
+    """Initialize the Streamlit session state for the Sequence Variability page."""
+    if SEQVAR_CALC_BTN not in st.session_state:
+        st.session_state[SEQVAR_CALC_BTN] = False
+        st.session_state[SEQVAR_CALCULATED] = False
+        st.session_state[SEQVAR_DF] = pd.DataFrame()
 
 
 def initialize() -> None:

--- a/src/app/frontend/download_data.py
+++ b/src/app/frontend/download_data.py
@@ -67,7 +67,9 @@ def download_seq_var_data(df: pd.DataFrame, species: str) -> None:
     # Convert the DataFrame to FASTA format string
     fasta_str = seqvar_df_to_fasta(df, species)
 
-    st.write("FASTA file is ready for download. Please click the button below to proceed.")
+    st.write(
+        "FASTA file is ready for download. Please click the button below to proceed."
+    )
 
     # Display a download button
     st.download_button(

--- a/src/app/frontend/download_data.py
+++ b/src/app/frontend/download_data.py
@@ -67,7 +67,7 @@ def download_seq_var_data(df: pd.DataFrame, species: str) -> None:
     # Convert the DataFrame to FASTA format string
     fasta_str = seqvar_df_to_fasta(df, species)
 
-    st.write("FASTA file ready for download!")
+    st.write("FASTA file is ready for download. Please click the button below to proceed.")
 
     # Display a download button
     st.download_button(

--- a/src/app/frontend/download_data.py
+++ b/src/app/frontend/download_data.py
@@ -1,7 +1,9 @@
 from typing import List
 
+import pandas as pd
 import streamlit as st
 
+from app.common.data_processing import seqvar_df_to_fasta
 from genetic_testing.routers import ncbi
 
 
@@ -46,3 +48,30 @@ def download_data(database: str, ids: List[int], search_term: str) -> None:
                 data=file_str,
                 file_name=f"{database}_{search_term}.fasta",
             )
+
+
+def download_seq_var_data(df: pd.DataFrame, species: str) -> None:
+    """Downloads sequence variability data as a FASTA file.
+
+    This function converts a DataFrame containing sequence variability data to
+    FASTA format and provides the option to
+    download the resulting FASTA file.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        A DataFrame containing sequence variability data.
+    species : str
+        The name of the species for which the data is being processed.
+    """
+    # Convert the DataFrame to FASTA format string
+    fasta_str = seqvar_df_to_fasta(df, species)
+
+    st.write("FASTA file ready for download!")
+
+    # Display a download button
+    st.download_button(
+        label="Download FASTA file",
+        data=fasta_str,
+        file_name=f"sequence_variability_{species}.fasta",
+    )

--- a/src/app/pages/2_Sequence-Variability.py
+++ b/src/app/pages/2_Sequence-Variability.py
@@ -2,10 +2,16 @@ from io import BytesIO
 
 import streamlit as st
 
+from app.common.constants import SEQVAR_CALC_BTN, SEQVAR_CALCULATED, SEQVAR_DF
 from app.common.data_processing import read_fasta
+from app.common.setup import initialize_session_state_seq_var
+from app.frontend.download_data import download_seq_var_data
 from genetic_testing.sequence_analysis.sequence_variability import (
     calculate_sequence_variability,
 )
+
+# Initialize the Streamlit session state for this page
+initialize_session_state_seq_var()
 
 # Streamlit app header
 st.header("Calculate Sequence Variability")
@@ -25,9 +31,30 @@ if uploaded_file is not None:
 
     # Display a button to calculate sequence variability
     if st.button("Calculate Sequence Variability"):
-        if not base_sequence:
-            st.warning("Please enter a base sequence before calculating.")
+        st.session_state[SEQVAR_CALC_BTN] = True
+
+# Button to calculate sequence variability is clicked
+if st.session_state[SEQVAR_CALC_BTN]:
+    if not base_sequence:
+        st.warning("Please enter a base sequence before calculating.")
+    else:
+        # Calculate sequence variability
+        if not st.session_state[SEQVAR_CALCULATED]:
+            st.session_state[SEQVAR_DF] = calculate_sequence_variability(
+                sequences, base_sequence
+            )
+            # Set the flag for calculation of sequence variability to True
+            st.session_state[SEQVAR_CALCULATED] = True
+
+        # Display the sequence variability data
+        if not st.session_state[SEQVAR_DF].empty:
+            st.write("Sequence Variability Data:")
+            st.dataframe(st.session_state[SEQVAR_DF])
+
+            # Enter the species name for downloading the data
+            species = st.text_input("Enter the species name:")
+
+            if st.button("Prepare for Download"):
+                download_seq_var_data(st.session_state[SEQVAR_DF], species)
         else:
-            df = calculate_sequence_variability(sequences, base_sequence)
-            st.write("Sequence Variability Calculation Results:")
-            st.dataframe(df)
+            st.write("No Sequence Variability Data to Download")

--- a/src/app/pages/2_Sequence-Variability.py
+++ b/src/app/pages/2_Sequence-Variability.py
@@ -54,7 +54,7 @@ if st.session_state[SEQVAR_CALC_BTN]:
             # Enter the species name for downloading the data
             species = st.text_input("Enter the species name:")
 
-            if st.button("Prepare for Download"):
+            if st.button("Prepare for download"):
                 download_seq_var_data(st.session_state[SEQVAR_DF], species)
         else:
-            st.write("No Sequence Variability Data to Download")
+            st.write("No Sequence Variability data to download")

--- a/src/app/pages/2_Sequence-Variability.py
+++ b/src/app/pages/2_Sequence-Variability.py
@@ -27,10 +27,10 @@ if uploaded_file is not None:
         st.write(sequences)
 
     # Display a form with an input box
-    base_sequence = st.text_input("Enter Base Sequence")
+    base_sequence = st.text_input("Enter base sequence")
 
     # Display a button to calculate sequence variability
-    if st.button("Calculate Sequence Variability"):
+    if st.button("Calculate sequence variability"):
         st.session_state[SEQVAR_CALC_BTN] = True
 
 # Button to calculate sequence variability is clicked
@@ -57,4 +57,4 @@ if st.session_state[SEQVAR_CALC_BTN]:
             if st.button("Prepare for download"):
                 download_seq_var_data(st.session_state[SEQVAR_DF], species)
         else:
-            st.write("No Sequence Variability data to download")
+            st.write("No sequence variability data to download")


### PR DESCRIPTION
Hi, I have made the following changes in this PR -

- Convert the Sequence Variability DataFrame to a FASTA format string
- Add a button to download the above string in the FASTA file

I have attached a screencast for your reference - 

[Seq-Var-FASTA-file-download.webm](https://github.com/uw-ssec/neglected-diagnostics/assets/25303819/b04c2d2b-4ba2-4624-a851-9e98ccfc8a10)

Closes #37 
