### PR TITLE
bug: Add form UI to Sequence Haplotypes page

### DIFF
--- a/src/app/common/constants.py
+++ b/src/app/common/constants.py
@@ -4,8 +4,6 @@ NCBI_DF = "NCBI_DF"
 NCBI_DF_FILTER = "NCBI_DF_FILTER"
 
 # Session State Keys for calculating sequence variability
-SEQVAR_CALC_BTN = "SEQVAR_CALC_BTN"
-SEQVAR_CALCULATED = "SEQVAR_CALCULATED"
 SEQVAR_DF = "SEQVAR_DF"
 
 # Session State Keys for calculating sequence variability table

--- a/src/app/common/setup.py
+++ b/src/app/common/setup.py
@@ -6,8 +6,6 @@ from app.common.constants import (
     NCBI_DF_FILTER,
     NCBI_SUMMARY_FORM,
     PAGE_LAYOUT,
-    SEQVAR_CALC_BTN,
-    SEQVAR_CALCULATED,
     SEQVAR_DF,
     SEQVAR_TABLE,
     SEQVAR_TABLE_BTN,
@@ -37,9 +35,7 @@ def _initialize_session_state() -> None:
 
 def init_session_state_seq_var() -> None:
     """Initialize the Streamlit session state for the Sequence Variability page."""
-    if SEQVAR_CALC_BTN not in st.session_state:
-        st.session_state[SEQVAR_CALC_BTN] = False
-        st.session_state[SEQVAR_CALCULATED] = False
+    if SEQVAR_DF not in st.session_state:
         st.session_state[SEQVAR_DF] = pd.DataFrame()
 
 

--- a/src/app/frontend/filter_dataframe.py
+++ b/src/app/frontend/filter_dataframe.py
@@ -32,6 +32,8 @@ def _preprocessing(df: pd.DataFrame):
     1. The "Species," "TaxId," "Id," "Gi," and "Status" columns are converted to categorical data type.
     2. The "CreateDate" and "UpdateDate" columns are converted to datetime format.
     """
+    if df.empty:
+        return df
     # Convert columns to categorical
     df["Species"] = df["Species"].astype("category")
     df["TaxId"] = df["TaxId"].astype("category")

--- a/src/app/pages/3_Sequence_Haplotypes.py
+++ b/src/app/pages/3_Sequence_Haplotypes.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 import streamlit as st
 
-from app.common.constants import SEQVAR_CALC_BTN, SEQVAR_CALCULATED, SEQVAR_DF
+from app.common.constants import SEQVAR_DF
 from app.common.data_processing import read_fasta
 from app.common.setup import init_session_state_seq_var
 from app.frontend.download_data import download_seq_var_data
@@ -26,35 +26,31 @@ if uploaded_file is not None:
         st.write("Uploaded sequences:")
         st.write(sequences)
 
+with st.form("seq_haplotypes"):
     # Display a form with an input box
     base_sequence = st.text_input("Enter base sequence")
 
-    # Display a button to calculate sequence variability
-    if st.button("Calculate sequence variability"):
-        st.session_state[SEQVAR_CALC_BTN] = True
-
-# Button to calculate sequence variability is clicked
-if st.session_state[SEQVAR_CALC_BTN]:
-    if not base_sequence:
-        st.warning("Please enter a base sequence before calculating.")
-    else:
-        # Calculate sequence variability
-        if not st.session_state[SEQVAR_CALCULATED]:
+    # Button to trigger sequence haplotypes calculation
+    submitted = st.form_submit_button("Find Sequence Haplotypes")
+    if submitted:
+        if not base_sequence:
+            st.warning("Please enter a base sequence before calculating.")
+        else:
+            # Calculate sequence haplotypes
             st.session_state[SEQVAR_DF] = calculate_sequence_variability(
                 sequences, base_sequence
             )
-            # Set the flag for calculation of sequence variability to True
-            st.session_state[SEQVAR_CALCULATED] = True
 
-        # Display the sequence variability data
-        if not st.session_state[SEQVAR_DF].empty:
-            st.write("Sequence Variability Data:")
-            st.dataframe(st.session_state[SEQVAR_DF])
 
-            # Enter the species name for downloading the data
-            species = st.text_input("Enter the species name:")
+# Display the sequence variability data
+if st.session_state[SEQVAR_DF] is not None:
+    st.write("Sequence Variability Data:")
+    st.dataframe(st.session_state[SEQVAR_DF])
 
-            if st.button("Prepare for download"):
-                download_seq_var_data(st.session_state[SEQVAR_DF], species)
-        else:
-            st.write("No sequence variability data to download")
+    # Enter the species name for downloading the data
+    species = st.text_input("Enter the species name:")
+
+    if st.button("Prepare for download"):
+        download_seq_var_data(st.session_state[SEQVAR_DF], species)
+else:
+    st.write("No sequence variability data to download")


### PR DESCRIPTION
Hi, I have made the following changes in this PR - 

- Return empty dataframe if user has not performed the search but clicks on `Add filters` checkbox. Closes #23
- Change the `Sequence Haplotypes` page to have a form UI to input the `Base Sequence` 