### PR TITLE
fix: issue #87, fasta format

### DIFF
--- a/src/app/pages/5_Find_Assay_Design_Area.py
+++ b/src/app/pages/5_Find_Assay_Design_Area.py
@@ -152,7 +152,7 @@ if st.session_state[TGT_AREA_FORM]:
         # Option 2: Download sequences as a FASTA file
         seqs = df[cols.assay_design_area].tolist()
         target_ids = df[cols.target_id].tolist()
-        fasta_data = "\n".join([f"{id}\n{seq}" for id, seq in zip(target_ids, seqs)])
+        fasta_data = "\n".join([f">{id}\n{seq}" for id, seq in zip(target_ids, seqs)])
         st.download_button(
             label="Download Fasta",
             data=fasta_data,


### PR DESCRIPTION
Fixes #87 

This was a regression from PR #84, missed the `>` prefix. Here's the new output:

```
>Assay_Design_Area_4
TCGAGCAGAACTCAGCCAGCCTGGCGCCCTTCTGGGAGATGACCAAATTTATAACGTAATTGTTACAGCCCATGCCTTCGTCATAATTTTCTTTATAGTCATACCGATTATGATCGGCGGCTTTGGAAACTGATTAATTCCTCTTATAATCGGGGCCCCCGACATAGCATTCCCCCGAATGAATAACATAAGTTTTTGACTTCTCCCTCCCTCCTTTCTTCTCCTCCTGGCCTCATCTGGAGTTGAAGCCGGCGCTGGCACCGGATGAACAGTCTACCCCCCTCTAGCAGGTAATCTTGC
>Assay_Design_Area_5
CTGGCGCCCTTCTGGGAGATGACCAAATTTATAACGTAATTGTTACAGCCCATGCCTTCGTCATAATTTTCTTTATAGTCATACCGATTATGATCGGCGGCTTTGGAAACTGATTAATTCCTCTTATAATCGGGGCCCCCGACATAGCATTCCCCCGAATGAATAACATAAGTTTTTGACTTCTCCCTCCCTCCTTTCTTCTCCTCCTGGCCTCATCTGGAGTTGAAGCCGGCGCTGGCACCGGATGAACAGTCTACCCCCCTCTAGCAGGTAATCTTGCCCACGCAGGAGCTTCCGTTG
>Assay_Design_Area_6
GACCAAATTTATAACGTAATTGTTACAGCCCATGCCTTCGTCATAATTTTCTTTATAGTCATACCGATTATGATCGGCGGCTTTGGAAACTGATTAATTCCTCTTATAATCGGGGCCCCCGACATAGCATTCCCCCGAATGAATAACATAAGTTTTTGACTTCTCCCTCCCTCCTTTCTTCTCCTCCTGGCCTCATCTGGAGTTGAAGCCGGCGCTGGCACCGGATGAACAGTCTACCCCCCTCTAGCAGGTAATCTTGCCCACGCAGGAGCTTCCGTTGACTTAACTATTTTTTCCCTC
```